### PR TITLE
[数据更新] 关于`其他论坛`分类下的站点名称规范

### DIFF
--- a/data/otherForum.json5
+++ b/data/otherForum.json5
@@ -2,12 +2,12 @@
 [
   {
     "其他论坛": [
-      ["国际论坛", "https://www.minecraftforum.net"],
-      ["香港社区", "https://www.minecraft-hk.com", "交流最新資訊、專業教學、遊戲伺服器、相關資源及心得分享"],
-      ["台湾论坛", "https://forum.gamer.com.tw/A.php?bsn=18673"],
-      ["基岩版台湾中文网", "https://forum.mcpe.tw"],
-      ["韩国论坛", "https://www.koreaminecraft.net"],
-      ["日本论坛", "https://minecraftforum.jp"],
+      ["Minecraft Forum", "https://www.minecraftforum.net"],
+      ["Minecraft-HK", "https://www.minecraft-hk.com", "交流最新資訊、專業教學、遊戲伺服器、相關資源及心得分享"],
+      ["巴哈姆特 Minecraft 哈拉板", "https://forum.gamer.com.tw/A.php?bsn=18673", "最新資訊及情報分享、精華好文查找、創作交流討論"],
+      ["Minecraft PE/BE 台湾中文网", "https://forum.mcpe.tw"],
+      ["한마포", "https://www.koreaminecraft.net"],
+      ["Minecraft Japan Forum", "https://forum.civa.jp/"],
     ]
   },
   {


### PR DESCRIPTION
在该 PR / Commit 中，对于外语论坛，将以 _站点的官方名称_ 代替 _〇〇论坛/社区_。