### PR TITLE
更新 PCL2 CE（社区版）版本

### DIFF
--- a/data/launcher.json5
+++ b/data/launcher.json5
@@ -112,13 +112,13 @@
     {
       "title": "Plain Craft Launcher 2 Community Edition",
       "abbr": "PCL2 社区版",
-      "download": "https://github.com/PCL-Community/PCL2-CE/releases/download/2.11.4/PCL2_CE_Release_x64.exe",
+      "download": "https://github.com/PCL-Community/PCL2-CE/releases/download/2.11.5/PCL2_CE_Release_x64.exe",
       // 太美的 pcl2ce开发组你们能不能别改文件名了 (╬▔皿▔)╯
-      "version": "2.11.4",
+      "version": "2.11.5",
       "github": "https://github.com/PCL-Community/PCL2-CE",
       "dev": {
-        "download": "https://github.com/PCL-Community/PCL2-CE/releases/download/2.11.2-beta.3/PCL2_CE_Beta_x64.exe",
-        "version": "2.11.2-beta.3"
+        "download": "https://github.com/PCL-Community/PCL2-CE/releases/download/2.11.3-beta.2/PCL2_CE_Beta_x64.exe",
+        "version": "2.11.3-beta.2"
       }
     },
     {


### PR DESCRIPTION
更新 PCL2 CE（社区版）版本 和 下载链接
version 2.11.4->2.11.5
dev version 2.11.2-beta.3->2.11.3-beta.2