### PR TITLE
添加正在开发的手机版启动器Amethyst启动器

### DIFF
--- a/THANKS.md
+++ b/THANKS.md
@@ -10,6 +10,7 @@
 感谢[籽岷](https://space.bilibili.com/686127)叔的宣传与支持。
 
 （籽岷的GitHub：[zimin1983](https://github.com/zimin1983)）
+
 排名不分先后。
 
 

--- a/THANKS.md
+++ b/THANKS.md
@@ -8,7 +8,7 @@
 诚心感谢所有贡献以及支持我们的个人/组织/项目等。
 
 感谢[籽岷](https://space.bilibili.com/686127)叔的宣传与支持。
-
+（籽岷的GitHub：[zimin1983](https://github.com/zimin1983)）
 排名不分先后。
 
 

--- a/THANKS.md
+++ b/THANKS.md
@@ -90,6 +90,8 @@ Thank you to all the people/organizations/projects that have contributed or supp
 
 Thank Uncle [Zi Min](https://space.bilibili.com/686127) for publicity and support.
 
+（Zi Min's GitHub：[zimin1983](https://github.com/zimin1983)）
+
 The list is in no particular order.
 
 

--- a/THANKS.md
+++ b/THANKS.md
@@ -8,6 +8,7 @@
 诚心感谢所有贡献以及支持我们的个人/组织/项目等。
 
 感谢[籽岷](https://space.bilibili.com/686127)叔的宣传与支持。
+
 （籽岷的GitHub：[zimin1983](https://github.com/zimin1983)）
 排名不分先后。
 

--- a/data/launcher.json5
+++ b/data/launcher.json5
@@ -54,7 +54,7 @@
     {
       "title": "Angel Aura Amethyst",
       "download": "https://github.com/AngelAuraMC/Amethyst-iOS/actions/runs/15523376984/artifacts/3284565553",
-      "version": "",
+      "version": "1.0",
       "github": "",
       "url": ""
     },

--- a/data/launcher.json5
+++ b/data/launcher.json5
@@ -55,7 +55,7 @@
       "title": "Angel Aura Amethyst",
       "download": "https://github.com/AngelAuraMC/Amethyst-iOS/actions/runs/15523376984/artifacts/3284565553",
       "version": "1.0",
-      "github": "",
+      "github": "https://github.com/AngelAuraMC/Amethyst-iOS",
       "url": ""
     },
   ],

--- a/data/launcher.json5
+++ b/data/launcher.json5
@@ -42,7 +42,7 @@
     {
       "title": "Angel Aura Amethyst",
       "dev":{
-        "download": "https://github.com/AngelAuraMC/Amethyst-iOS/actions/runs/15523376984/artifacts/3284565553",
+        "download": "https://github.com/AngelAuraMC/Amethyst-Android/actions/runs/15660924693/artifacts/3330366203",
         "version": "1.0"
       }
       "github": "https://github.com/AngelAuraMC/Amethyst-Android",

--- a/data/launcher.json5
+++ b/data/launcher.json5
@@ -40,7 +40,7 @@
       "github": "https://github.com/ZalithLauncher/ZalithLauncher"
     },
   ],
-  // ===================================
+  // =====！==============================
   // 适用于 苹果手机/苹果平板 的启动器
   // ===================================
   "iOSLauncher": [
@@ -50,6 +50,9 @@
       "version": "2.2",
       "github": "https://github.com/PojavLauncherTeam/PojavLauncher_iOS",
       "url": "https://pojavlauncher.app"
+    },
+    {
+      "title": ""
     },
   ],
   // ==============================

--- a/data/launcher.json5
+++ b/data/launcher.json5
@@ -54,8 +54,8 @@
     {
       "title": "Angel Aura Amethyst",
       "download": "",
-      "version": ""
-      "github": ""
+      "version": "",
+      "github": "",
       "url": ""
     },
   ],

--- a/data/launcher.json5
+++ b/data/launcher.json5
@@ -39,8 +39,17 @@
       "version": "1.4.0",
       "github": "https://github.com/ZalithLauncher/ZalithLauncher"
     },
+    {
+      "title": "Angel Aura Amethyst",
+      "dev":{
+        "download": "https://github.com/AngelAuraMC/Amethyst-iOS/actions/runs/15523376984/artifacts/3284565553",
+        "version": "1.0"
+      }
+      "github": "https://github.com/AngelAuraMC/Amethyst-Android",
+      "url": "https://wiki.angelauramc.dev/wiki"
+    },
   ],
-  // =====！==============================
+  // ===================================
   // 适用于 苹果手机/苹果平板 的启动器
   // ===================================
   "iOSLauncher": [
@@ -53,8 +62,10 @@
     },
     {
       "title": "Angel Aura Amethyst",
-      "download": "https://github.com/AngelAuraMC/Amethyst-iOS/actions/runs/15523376984/artifacts/3284565553",
-      "version": "1.0",
+      "dev":{
+        "download": "https://github.com/AngelAuraMC/Amethyst-iOS/actions/runs/15523376984/artifacts/3284565553",
+        "version": "1.0"
+      }
       "github": "https://github.com/AngelAuraMC/Amethyst-iOS",
       "url": "https://wiki.angelauramc.dev/wiki"
     },

--- a/data/launcher.json5
+++ b/data/launcher.json5
@@ -53,7 +53,7 @@
     },
     {
       "title": "Angel Aura Amethyst",
-      "download": "",
+      "download": "https://github.com/AngelAuraMC/Amethyst-iOS/actions/runs/15523376984/artifacts/3284565553",
       "version": "",
       "github": "",
       "url": ""

--- a/data/launcher.json5
+++ b/data/launcher.json5
@@ -52,7 +52,11 @@
       "url": "https://pojavlauncher.app"
     },
     {
-      "title": ""
+      "title": "Angel Aura Amethyst",
+      "download": "",
+      "version": ""
+      "github": ""
+      "url": ""
     },
   ],
   // ==============================

--- a/data/launcher.json5
+++ b/data/launcher.json5
@@ -42,7 +42,7 @@
     {
       "title": "Angel Aura Amethyst",
       "github": "https://github.com/AngelAuraMC/Amethyst-Android",
-      "url": "https://wiki.angelauramc.dev/wiki"
+      "url": "https://wiki.angelauramc.dev/wiki",
       "dev":{
         "download": "https://github.com/AngelAuraMC/Amethyst-Android/actions/runs/15660924693/artifacts/3330366203",
         "version": "1.0"
@@ -62,8 +62,8 @@
     },
     {
       "title": "Angel Aura Amethyst",
-       "github": "https://github.com/AngelAuraMC/Amethyst-iOS",
-      "url": "https://wiki.angelauramc.dev/wiki"
+      "github": "https://github.com/AngelAuraMC/Amethyst-iOS",
+      "url": "https://wiki.angelauramc.dev/wiki",
       "dev":{
         "download": "https://github.com/AngelAuraMC/Amethyst-iOS/actions/runs/15523376984/artifacts/3284565553",
         "version": "1.0"

--- a/data/launcher.json5
+++ b/data/launcher.json5
@@ -56,7 +56,7 @@
       "download": "https://github.com/AngelAuraMC/Amethyst-iOS/actions/runs/15523376984/artifacts/3284565553",
       "version": "1.0",
       "github": "https://github.com/AngelAuraMC/Amethyst-iOS",
-      "url": ""
+      "url": "https://wiki.angelauramc.dev/wiki"
     },
   ],
   // ==============================

--- a/data/launcher.json5
+++ b/data/launcher.json5
@@ -41,12 +41,12 @@
     },
     {
       "title": "Angel Aura Amethyst",
+      "github": "https://github.com/AngelAuraMC/Amethyst-Android",
+      "url": "https://wiki.angelauramc.dev/wiki"
       "dev":{
         "download": "https://github.com/AngelAuraMC/Amethyst-Android/actions/runs/15660924693/artifacts/3330366203",
         "version": "1.0"
       }
-      "github": "https://github.com/AngelAuraMC/Amethyst-Android",
-      "url": "https://wiki.angelauramc.dev/wiki"
     },
   ],
   // ===================================
@@ -62,12 +62,12 @@
     },
     {
       "title": "Angel Aura Amethyst",
+       "github": "https://github.com/AngelAuraMC/Amethyst-iOS",
+      "url": "https://wiki.angelauramc.dev/wiki"
       "dev":{
         "download": "https://github.com/AngelAuraMC/Amethyst-iOS/actions/runs/15523376984/artifacts/3284565553",
         "version": "1.0"
       }
-      "github": "https://github.com/AngelAuraMC/Amethyst-iOS",
-      "url": "https://wiki.angelauramc.dev/wiki"
     },
   ],
   // ==============================


### PR DESCRIPTION
Angel Aura Amethyst启动器是AngelAuraMC团队（原PojavLauncherTeam团队）基于pojavlauncher制作的新启动器，支持ios和安卓双平台
有关pojavlauncher停更原因：【再见！PojavLauncher宣布归档停更,Angel Aura Amethyst立项接替开发-哔哩哔哩】 https://b23.tv/vIpCxlN
有关Amethyst启动器的开箱视频：【[全网首开]3A启动器来了！全新的内容，但是是毛坯房？-哔哩哔哩】 https://b23.tv/qMiRt7V