### PR TITLE
feat(utilityWebsite): 添加 FCL 第三方下载站

### DIFF
--- a/data/utilityWebsite.jsonc
+++ b/data/utilityWebsite.jsonc
@@ -66,7 +66,8 @@
       ["MC-NEO光影站", "https://www.neoshader.com/", "全国首个全授权光影站"],
       ["MC原版模组入门教程", "https://icer233.us.kg/VanillaModTutorial/", "数据包/资源包 指南"],
       ["ForgePixel中文皮肤站", "https://forgepixel.com/", "免费获取皮肤/披风 以及免费提供第三方登录服务"],
-      ["GTMC", "https://techmc.wiki", "系统性的技术向MC理论归档"]
+      ["GTMC", "https://techmc.wiki", "系统性的技术向MC理论归档"],
+      ["FCL第三方下载站", "https://foldcraftlauncher.cn/", "安全，可靠，快速的fcl下载与安卓JAVA相关资源获取站。"]
     ]
   },
   {


### PR DESCRIPTION
在 utilityWebsite.jsonc 文件中添加了新的实用网站信息：
- 名称：FCL第三方下载站
- 地址：https://foldcraftlauncher.cn/
- 描述：安全，可靠，快速的fcl下载与安卓JAVA相关资源获取站。