### PR TITLE
添加 ServerBuddy 服务器发现平台

### DIFF
--- a/data/utilityWebsite.json
+++ b/data/utilityWebsite.json
@@ -288,6 +288,11 @@
         "desc": "实时最佳人气服务器列表，面向全球"
       },
       {
+        "name": "ServerBuddy",
+        "url": "https://serverbuddy.net/",
+        "desc": "全球 Java/基岩版服务器发现平台，提供实时状态、玩家数历史、在线率、MOTD 与版本历史"
+      },
+      {
         "name": "mcl.ist",
         "url": "https://mcl.ist",
         "desc": "面向全球"


### PR DESCRIPTION
## 内容

将 [ServerBuddy](https://serverbuddy.net/) 加入 `找服玩` 分类。ServerBuddy 面向全球 Java 和基岩版服务器，提供实时状态、玩家数历史、在线率、MOTD 与版本历史。

## 验证

- [x] `jq empty data/utilityWebsite.json`
- [x] `git diff --check`
- [x] ServerBuddy 首页返回 HTTP 200

Disclosure: this submission is made on behalf of ServerBuddy.
